### PR TITLE
Rule setup for Kotlin

### DIFF
--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -39,6 +39,8 @@
 (declare-function codemetrics-rules--elisp-special-form "codemetrics.el")
 (declare-function codemetrics-rules--elisp-list "codemetrics.el")
 (declare-function codemetrics-rules--java-outer-loop "codemetrics.el")
+(declare-function codemetrics-rules--kotlin-outer-loop "codemetrics.el")
+(declare-function codemetrics-rules--kotlin-elvis-operator "codemetrics.el")
 (declare-function codemetrics-rules--julia-macro-expression "codemetrics.el")
 (declare-function codemetrics-rules--lua-binary-expressions "codemetrics.el")
 (declare-function codemetrics-rules--ruby-binary "codemetrics.el")
@@ -165,6 +167,26 @@
     ("||"                . codemetrics-rules--logical-operators)
     (macro_expression    . codemetrics-rules--julia-macro-expression)
     (call_expression     . codemetrics-rules--recursion)))
+
+(defun codemetrics-rules-kotlin ()
+  "Return rules for Kotlin."
+  `((class_declaration    . codemetrics-rules--class-declaration)
+    (object_declaration   . codemetrics-rules--class-declaration)
+    (function_declaration . codemetrics-rules--method-declaration)
+    (lambda_literal       . (0 t))  ; don't score, but increase nested level
+    (anonymous_function   . (0 t))  ; should in theory have same effect as lambda
+    (if_expression        . (1 t))
+    (when_expression      . (1 t))
+    (while_statement      . (1 t))
+    (do_while_statement   . (1 t))
+    (for_statement        . (1 t))
+    (catch_block          . (1 t))
+    (finally_block        . (1 t))
+    ("&&"                 . codemetrics-rules--logical-operators)
+    ("||"                 . codemetrics-rules--logical-operators)
+    ("?:"                 . codemetrics-rules--kotlin-elvis-operator)
+    (jump_expression      . codemetrics-rules--kotlin-outer-loop) ; break and continue
+    (call_expression      . codemetrics-rules--recursion)))
 
 (defun codemetrics-rules-lua ()
   "Return rules for Lua."

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -332,19 +332,25 @@ more information."
       '(0 nil))
     '(1 nil)))
 
-(defun codemetrics-rules--logical-operators (node &rest _)
-  "Define rule for logical operators.
+(defun codemetrics-rules--operators (node operators)
+  "Define rule for operators from OPERATORS argument.
 
 For argument NODE, see function `codemetrics-analyze' for more information."
   (codemetrics-with-complexity
     (let* ((parent (tsc-get-parent node))
            (parent-text (tsc-node-text parent))
            (sequence)
-           (count (codemetrics--s-count-matches '("||" "&&") parent-text)))
+           (count (codemetrics--s-count-matches operators parent-text)))
       (when (<= 2 count)
         (setq sequence t))
       (list (if sequence 1 0) nil))
     '(1 nil)))
+
+(defun codemetrics-rules--logical-operators (node &rest _)
+  "Define rule for logical operators.
+
+For argument NODE, see function `codemetrics-analyze' for more information."
+  (codemetrics-rules--operators node '("&&" "||")))
 
 (defun codemetrics-rules--outer-loop (node _depth _nested &optional children)
   "Define rule for outer loop (jump), `break' and `continue' statements.
@@ -446,12 +452,7 @@ For argument NODE, see function `codemetrics-analyze' for more information."
   "Define rule for the Elvis operator ?:.
 
 For argument NODE, see function `codemetrics-analyze' for more information."
-  (codemetrics-with-complexity
-    (let* ((parent (tsc-get-parent node))
-           (parent-text (tsc-node-text parent))
-           (count (codemetrics--s-count-matches '("?:") parent-text)))
-      (list (if (<= 2 count) 1 0) nil))
-    '(1 nil)))
+  (codemetrics-rules--operators node '("?:")))
 
 (defun codemetrics-rules--julia-macro-expression (node &rest _)
   "Define rule for Julia `macro' expression.

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -65,6 +65,7 @@
     (js2-mode        . ,(codemetrics-rules-javascript))
     (js3-mode        . ,(codemetrics-rules-javascript))
     (julia-mode      . ,(codemetrics-rules-julia))
+    (kotlin-mode     . ,(codemetrics-rules-kotlin))
     (lua-mode        . ,(codemetrics-rules-lua))
     (php-mode        . ,(codemetrics-rules-php))
     (python-mode     . ,(codemetrics-rules-python))
@@ -434,6 +435,23 @@ For argument NODE, see function `codemetrics-analyze' for more information."
 
 For argument NODE, see function `codemetrics-analyze' for more information."
   (codemetrics-rules--outer-loop node nil nil 2))
+
+(defun codemetrics-rules--kotlin-outer-loop (node &rest _)
+  "Define rule for Java outer loop (jump), `break' and `continue' statements.
+
+For argument NODE, see function `codemetrics-analyze' for more information."
+  (codemetrics-rules--outer-loop node nil nil 1))
+
+(defun codemetrics-rules--kotlin-elvis-operator (node &rest _)
+  "Define rule for the Elvis operator ?:.
+
+For argument NODE, see function `codemetrics-analyze' for more information."
+  (codemetrics-with-complexity
+    (let* ((parent (tsc-get-parent node))
+           (parent-text (tsc-node-text parent))
+           (count (codemetrics--s-count-matches '("?:") parent-text)))
+      (list (if (<= 2 count) 1 0) nil))
+    '(1 nil)))
 
 (defun codemetrics-rules--julia-macro-expression (node &rest _)
   "Define rule for Julia `macro' expression.


### PR DESCRIPTION
## General info
My attempt at setup for Kotlin. Seems to work nicely with the small experiments I have done so far. Constructed some stupid code examples for show it in action:
<img width="579" alt="image" src="https://github.com/emacs-vs/codemetrics/assets/5732795/0446a879-e96e-4aeb-8b5c-b51518dcf405">



## Implementation details
I based this on [the Kotlin tree-sitter grammar](https://github.com/fwcd/tree-sitter-kotlin), which is linked to from [the tree-sitter-langs repo](https://github.com/emacs-tree-sitter/tree-sitter-langs). From the readme, I understood that you wanted the grammars in use to be referenced in that repo.


I'm no expert on cognitive complexity, but from my understanding the calculation should be correct. I was heavily inspired by the rule definition for Java. Some minor notes to explain my thinking on some of the code:
- `codemetrics-rules--kotlin-outer-loop`: This one is almost equal to the one in the Java definition, but sending 1 as the children parameter. I have trouble understanding why it is 2 for Java and 1 for Rust.  Kept it as a separate function to easily be able to tweak it.
- Refactored the `codemetrics-rules--logical-operators` function body into a new function, as I have created a variant for the Elvis operator in Kotlin. The bodies on the logical- and Elvis operator functions turned out almost identical except which strings they checked for. 
- In my understanding, using the Elvis operator (`?:`) will have the same effect on cognitive complexity as nesting the logical operators. Therefore I added a simple rule for it.