### PR TITLE
Super simple proof of concept for testing

### DIFF
--- a/Eask
+++ b/Eask
@@ -17,3 +17,8 @@
 (depends-on "s")
 
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432
+
+(development
+ (depends-on "kotlin-mode")
+ (depends-on "go-mode")
+ (depends-on "tree-sitter-langs"))

--- a/Eask
+++ b/Eask
@@ -21,4 +21,5 @@
 (development
  (depends-on "kotlin-mode")
  (depends-on "go-mode")
- (depends-on "tree-sitter-langs"))
+ (depends-on "tree-sitter-langs")
+ (depends-on "dash"))

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ EASK ?= eask
 
 .PHONY: clean checkdoc lint package install compile test
 
-ci: clean package install compile
+ci: clean package install test compile
 
 package:
 	@echo "Packaging..."
@@ -11,7 +11,7 @@ package:
 
 install:
 	@echo "Installing..."
-	$(EASK) install
+	$(EASK) install --dev
 
 compile:
 	@echo "Compiling..."
@@ -19,7 +19,7 @@ compile:
 
 test:
 	@echo "Testing..."
-	$(EASK) test ert ./test/*.el
+	$(EASK) test ert-runner
 
 checkdoc:
 	@echo "Run checkdoc..."

--- a/test/go-test.el
+++ b/test/go-test.el
@@ -1,0 +1,14 @@
+(require 'codemetrics)
+(require 'go-mode)
+
+(add-to-list 'load-path "test")
+(require 'utils)
+
+(codemetrics-test simple-go-code
+                  "test/go/Simple.go"
+                  go-mode
+                  '(2
+                    (function_declaration . 0)
+                    (if_statement . 1)
+                    (call_expression . 0)
+                    (for_statement . 1)))

--- a/test/go/Simple.go
+++ b/test/go/Simple.go
@@ -1,0 +1,10 @@
+import "fmt"
+
+func main() {
+	mynum := 2
+	if 2 == mynum {
+		fmt.Println("The number is 2")
+	}
+	for {
+	}
+}

--- a/test/kotlin-test.el
+++ b/test/kotlin-test.el
@@ -1,0 +1,14 @@
+(require 'codemetrics)
+(require 'kotlin-mode)
+
+(add-to-list 'load-path "test")
+(require 'utils)
+
+(codemetrics-test simple-kotlin-code
+                  "test/kotlin/Simple.kt"
+                  kotlin-mode
+                  '(2
+                    (function_declaration . 0)
+                    (if_expression . 1)
+                    (for_statement . 1)
+                    (call_expression . 0)))

--- a/test/kotlin/Simple.kt
+++ b/test/kotlin/Simple.kt
@@ -1,0 +1,7 @@
+fun myfun() {
+    val myval = 2
+    if(2 == myval) {
+    }
+    for(i in listOf(1,2,3)) {
+    }
+}

--- a/test/utils.el
+++ b/test/utils.el
@@ -1,0 +1,23 @@
+(require 'dash)
+
+(defmacro codemetrics-test (test-name file major-mode expected-result)
+  "Create a codemetrics test named TEST-NAME using FILE in MAJOR-MODE.
+Expecting result EXPECTED-RESULT."
+  `(ert-deftest ,test-name ()
+     (with-current-buffer (find-file-noselect ,file)
+       (,major-mode)
+       (tree-sitter-mode)
+       (let* ((codemetrics-results (codemetrics-buffer))
+              (total-score (car codemetrics-results))
+              (expressions-and-scores (codemetrics-test-utils-expression-scores codemetrics-results)))
+         (should (equal ,expected-result
+                        (cons total-score
+                              expressions-and-scores)))))))
+
+(defun codemetrics-test-utils-expression-scores (analyze-result)
+  "Helper method to get a list of simple expression + score pairs to work with."
+  (--map (cons (tsc-node-type (car it))
+               (nth 2 it))
+         (cdr analyze-result)))
+
+(provide 'utils)


### PR DESCRIPTION
# Motivation
When working on fixing errors (like #7), we might chance global methods used by many rules. This might lead to changes, which in some cases can lead to regression on older errors (or introducing new ones). For this, as well as verifying errors, it can be useful to have a test harness. I often enjoy making a small test to verify the defect/issue when I work on bugs. 


# Implementation details
I imagine that tests quickly go un-maintained if they are hard to write. My vision was therefore a very simple setup. Let us take the go-test as en example:
```emacs-lisp
(codemetrics-test simple-go-code
                  "test/go/Simple.go"
                  go-mode
                  '(2
                    (function_declaration . 0)
                    (if_statement . 1)
                    (call_expression . 0)
                    (for_statement . 1)))
```

The first argument to the macro is the test name, the next is the filename we test (source code to analyze), then our major-mode, and last our expected result. The expected result is the total score, and the calculation for each expression in the file. To make it easier to work with, I made a simple utility function to convert the analysis result to the format above.

The tests are still ert tests, they are just hidden behind the macro `codemetrics-test`.


# Other
I have made this very small to begin with on purpose. No point in wasting too much time on making 100s of tests if you hate the main setup 🙂 If you think it looks okay, I can make more tests for more languages. It will also be of great help when solving incorrect calculation issue, as well as one other possible issue I'm currently looking into.


This is probably far from perfect, so feel free to suggest improvements if you like the idea 🙂 


If you dislike the idea, feel free to say so, and I will close it and not bother you about it again 🙂 