### PR TITLE
Fixing Kotlin recursion not registering properly

### DIFF
--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -41,6 +41,8 @@
 (declare-function codemetrics-rules--java-outer-loop "codemetrics.el")
 (declare-function codemetrics-rules--kotlin-outer-loop "codemetrics.el")
 (declare-function codemetrics-rules--kotlin-elvis-operator "codemetrics.el")
+(declare-function codemetrics-rules--kotlin-function-declaration "codemetrics.el")
+(declare-function codemetrics-rules--kotlin-recursion "codemetrics.el")
 (declare-function codemetrics-rules--julia-macro-expression "codemetrics.el")
 (declare-function codemetrics-rules--lua-binary-expressions "codemetrics.el")
 (declare-function codemetrics-rules--ruby-binary "codemetrics.el")
@@ -172,7 +174,7 @@
   "Return rules for Kotlin."
   `((class_declaration    . codemetrics-rules--class-declaration)
     (object_declaration   . codemetrics-rules--class-declaration)
-    (function_declaration . codemetrics-rules--method-declaration)
+    (function_declaration . codemetrics-rules--kotlin-function-declaration)
     (lambda_literal       . (0 t))  ; don't score, but increase nested level
     (anonymous_function   . (0 t))  ; should in theory have same effect as lambda
     (if_expression        . (1 t))
@@ -187,7 +189,7 @@
     ("?:"                 . codemetrics-rules--kotlin-elvis-operator)
     ("break"              . codemetrics-rules--kotlin-outer-loop)
     ("continue"           . codemetrics-rules--kotlin-outer-loop)
-    (call_expression      . codemetrics-rules--recursion)))
+    (call_expression      . codemetrics-rules--kotlin-recursion)))
 
 (defun codemetrics-rules-lua ()
   "Return rules for Lua."

--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -185,7 +185,8 @@
     ("&&"                 . codemetrics-rules--logical-operators)
     ("||"                 . codemetrics-rules--logical-operators)
     ("?:"                 . codemetrics-rules--kotlin-elvis-operator)
-    (jump_expression      . codemetrics-rules--kotlin-outer-loop) ; break and continue
+    ("break"              . codemetrics-rules--kotlin-outer-loop)
+    ("continue"           . codemetrics-rules--kotlin-outer-loop)
     (call_expression      . codemetrics-rules--recursion)))
 
 (defun codemetrics-rules-lua ()

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -317,13 +317,13 @@ For argument DEPTH, see function `codemetrics-analyze' for more information."
       '(0 nil))
     '(1 nil)))
 
-(defun codemetrics-rules--method-declaration-using-identifier-name (node depth nested identifier-name)
-  "Define rule for function/method declaration using node name IDENTIFIER-NAME.
+(defun codemetrics-rules--method-declaration-using-node-name (node depth nested node-name)
+  "Define rule for function/method declaration using node name NODE-NAME.
 
 For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
 more information."
-  ;; XXX: Record the recursion method name (identifier) identifier by identifier-name
-  (when-let ((node (car (codemetrics--tsc-find-children node identifier-name))))
+  ;; XXX: Record the recursion method name (identifier) identifier by node-name
+  (when-let ((node (car (codemetrics--tsc-find-children node node-name))))
     (setq codemetrics--recursion-identifier (tsc-node-text node)))
   (codemetrics-with-complexity
     ;; These magic numbers are observed by TreeSitter AST.
@@ -337,7 +337,7 @@ more information."
 
 For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
 more information."
-  (codemetrics-rules--method-declaration-using-identifier-name node depth nested "identifier"))
+  (codemetrics-rules--method-declaration-using-node-name node depth nested "identifier"))
 
 ;; Kotlin uses its own node name for function identifiers
 (defun codemetrics-rules--kotlin-function-declaration (node depth nested)
@@ -345,7 +345,7 @@ more information."
 
 For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
 more information."
-  (codemetrics-rules--method-declaration-using-identifier-name node depth nested "simple_identifier"))
+  (codemetrics-rules--method-declaration-using-node-name node depth nested "simple_identifier"))
 
 (defun codemetrics-rules--operators (node operators)
   "Define rule for operators from OPERATORS argument.
@@ -375,10 +375,10 @@ For argument NODE, see function `codemetrics-analyze' for more information."
     (list (if (<= (tsc-count-children node) children) 0 1) nil)
     '(0 nil)))
 
-(defun codemetrics-rules--recursion-using-identifier-name (node identifier-name)
-  "General recursion rule using the node name IDENTIFIER-NAME as the function name."
+(defun codemetrics-rules--recursion-using-node-name (node node-name)
+  "General recursion rule using the node name NODE-NAME as the function name."
   (codemetrics-with-complexity
-    (if-let* ((identifier (car (codemetrics--tsc-find-children node identifier-name)))
+    (if-let* ((identifier (car (codemetrics--tsc-find-children node node-name)))
               (text (tsc-node-text identifier))
               ((equal text codemetrics--recursion-identifier)))
         '(1 nil)
@@ -388,13 +388,12 @@ For argument NODE, see function `codemetrics-analyze' for more information."
 
 (defun codemetrics-rules--recursion (node &rest _)
   "Handle recursion for most languages uses `identifier' as the keyword."
-  (codemetrics-rules--recursion-using-identifier-name node "identifier"))
+  (codemetrics-rules--recursion-using-node-name node "identifier"))
 
 ;; Kotlin uses its own name for the identifiers
 (defun codemetrics-rules--kotlin-recursion (node &rest _)
   "Handle recursion for Kotlin."
-  (codemetrics-rules--recursion-using-identifier-name node "simple_identifier"))
-
+  (codemetrics-rules--recursion-using-node-name node "simple_identifier"))
 
 (defun codemetrics-rules--elixir-call (node depth nested)
   "Define rule for Elixir `call' declaration.

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -332,6 +332,21 @@ more information."
       '(0 nil))
     '(1 nil)))
 
+;; Kotlin uses its own node name for function identifiers
+(defun codemetrics-rules--kotlin-function-declaration (node depth nested)
+  "Define rule for function declaration in Kotlin.
+
+For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
+more information."
+  (when-let ((node (car (codemetrics--tsc-find-children node "simple_identifier"))))
+    (setq codemetrics--recursion-identifier (tsc-node-text node)))
+  (codemetrics-with-complexity
+    ;; These magic numbers are observed by TreeSitter AST.
+    (if (or (<= 5 depth) (<= 3 nested))
+        '(1 nil)
+      '(0 nil))
+    '(1 nil)))
+
 (defun codemetrics-rules--operators (node operators)
   "Define rule for operators from OPERATORS argument.
 
@@ -370,6 +385,19 @@ For argument NODE, see function `codemetrics-analyze' for more information."
       '(0 nil))
     ;; do nothing
     '(0 nil)))
+
+;; Kotlin uses its own name for the identifiers
+(defun codemetrics-rules--kotlin-recursion (node &rest _)
+  "Handle recursion for Kotlin."
+  (codemetrics-with-complexity
+    (if-let* ((identifier (car (codemetrics--tsc-find-children node "simple_identifier")))
+              (text (tsc-node-text identifier))
+              ((equal text codemetrics--recursion-identifier)))
+        '(1 nil)
+      '(0 nil))
+    ;; do nothing
+    '(0 nil)))
+
 
 (defun codemetrics-rules--elixir-call (node depth nested)
   "Define rule for Elixir `call' declaration.

--- a/test/java-test.el
+++ b/test/java-test.el
@@ -1,0 +1,35 @@
+;;; java-test.el --- Java language tests for codemetrics.el  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Marie Katrine Ekeberg
+
+;; Author: Marie Katrine Ekeberg <mke@themkat.net>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'codemetrics)
+
+(codemetrics-test java-recursion
+  "test/java/Recursion.java"
+  java-mode
+  '(2
+    (class_declaration . 0)
+    (method_declaration . 0)
+    (if_statement . 1)
+    (method_invocation . 1)))
+
+;;; java-test.el ends here

--- a/test/java/Recursion.java
+++ b/test/java/Recursion.java
@@ -1,0 +1,11 @@
+class Recursion {
+
+    public int factorial(int n) {
+        if (n <= 1) {
+            return 1;
+        }
+
+        return n * factorial(n - 1);
+    }
+    
+}

--- a/test/kotlin-test.el
+++ b/test/kotlin-test.el
@@ -33,4 +33,12 @@
     (for_statement . 1)
     (call_expression . 0)))
 
+(codemetrics-test kotlin-recursion
+  "test/kotlin/Recursion.kt"
+  kotlin-mode
+  '(2
+    (function_declaration . 0)
+    (if_expression . 1)
+    (call_expression . 1)))
+
 ;;; kotlin-test.el ends here

--- a/test/kotlin-test.el
+++ b/test/kotlin-test.el
@@ -41,4 +41,17 @@
     (if_expression . 1)
     (call_expression . 1)))
 
+(codemetrics-test kotlin-break-continue
+  "test/kotlin/BreakContinue.kt"
+  kotlin-mode
+  '(8
+    (function_declaration . 0)
+    (call_expression . 0)
+    (for_statement . 1)
+    (if_expression . 2)
+    ("break" . 1)
+    (for_statement . 1)
+    (if_expression . 2)
+    ("continue" . 1)))
+
 ;;; kotlin-test.el ends here

--- a/test/kotlin/BreakContinue.kt
+++ b/test/kotlin/BreakContinue.kt
@@ -1,0 +1,17 @@
+fun myfunction() {
+    val myList = listOf(1,2,3)
+
+    // Some first pass processing
+    for(i in myList) {
+        if (i == 2) {
+            break;
+        }
+    }
+
+    // Some second pass processing
+    for(i in myList) {
+        if (i == 1) {
+            continue;
+        }
+    }
+}

--- a/test/kotlin/Recursion.kt
+++ b/test/kotlin/Recursion.kt
@@ -1,0 +1,7 @@
+fun factorial(n: Int): Int {
+    if (n <= 1) {
+        return 1
+    }
+
+    return n * factorial(n - 1)
+} 


### PR DESCRIPTION
It seems like Kotlin recursion is not handled properly. This is because of the grammar using the node name `simple_identifier` instead of `identifier` like most grammars do.


`jump_expression` included returns as well, so changed it to explicit break and continues for now. ~Might have to look further into it later, but we will see.~
EDIT: Added tests right away, because why wait 😛 


Thanks to having a test harness, I could work in a TDD-ish way this time 😄 Also added a test for Java to verify the general recursion case.