### PR TITLE
Improve bash test coverage and fix recursion bug

### DIFF
--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -35,6 +35,8 @@
 (declare-function codemetrics-rules--logical-operators "codemetrics.el")
 (declare-function codemetrics-rules--recursion "codemetrics.el")
 
+(declare-function codemetrics-rules--bash-function-declaration "codemetrics.el")
+(declare-function codemetrics-rules--bash-recursion "codemetrics.el")
 (declare-function codemetrics-rules--elixir-call "codemetrics.el")
 (declare-function codemetrics-rules--elisp-special-form "codemetrics.el")
 (declare-function codemetrics-rules--elisp-list "codemetrics.el")
@@ -57,11 +59,11 @@
 
 (defun codemetrics-rules-bash ()
   "Return rules for Bash."
-  `((function_definition . codemetrics-rules--method-declaration)
+  `((function_definition . codemetrics-rules--bash-function-declaration)
     (if_statement        . (1 t))
     (while_statement     . (1 t))
     (for_statement       . (1 t))
-    (command             . codemetrics-rules--recursion)))
+    (command             . codemetrics-rules--bash-recursion)))
 
 (defun codemetrics-rules-c ()
   "Return rules for C."

--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -35,8 +35,6 @@
 (declare-function codemetrics-rules--logical-operators "codemetrics.el")
 (declare-function codemetrics-rules--recursion "codemetrics.el")
 
-(declare-function codemetrics-rules--bash-function-declaration "codemetrics.el")
-(declare-function codemetrics-rules--bash-recursion "codemetrics.el")
 (declare-function codemetrics-rules--elixir-call "codemetrics.el")
 (declare-function codemetrics-rules--elisp-special-form "codemetrics.el")
 (declare-function codemetrics-rules--elisp-list "codemetrics.el")
@@ -50,6 +48,7 @@
 (declare-function codemetrics-rules--ruby-binary "codemetrics.el")
 (declare-function codemetrics-rules--rust-outer-loop "codemetrics.el")
 (declare-function codemetrics-rules--scala-call-expression "codemetrics.el")
+(declare-function codemetrics-rules--method-declaration-using-node-name "codemetrics.el")
 
 ;;
 ;; (@* "Rules" )
@@ -59,11 +58,13 @@
 
 (defun codemetrics-rules-bash ()
   "Return rules for Bash."
-  `((function_definition . codemetrics-rules--bash-function-declaration)
+  `((function_definition . (lambda (node depth nested)
+                             (codemetrics-rules--method-declaration-using-node-name node depth nested "word")))
     (if_statement        . (1 t))
     (while_statement     . (1 t))
     (for_statement       . (1 t))
-    (command             . codemetrics-rules--bash-recursion)))
+    (command             . (lambda (node &rest _)
+                             (codemetrics-rules--recursion-using-node-name node "command_name")))))
 
 (defun codemetrics-rules-c ()
   "Return rules for C."

--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -33,7 +33,10 @@
 (declare-function codemetrics-rules--class-declaration "codemetrics.el")
 (declare-function codemetrics-rules--method-declaration "codemetrics.el")
 (declare-function codemetrics-rules--logical-operators "codemetrics.el")
+(declare-function codemetrics-rules--method-declaration-using-node-name "codemetrics.el")
+(declare-function codemetrics-rules--operators "codemetrics.el")
 (declare-function codemetrics-rules--recursion "codemetrics.el")
+(declare-function codemetrics-rules--recursion-using-node-name "codemetrics.el")
 
 (declare-function codemetrics-rules--elixir-call "codemetrics.el")
 (declare-function codemetrics-rules--elisp-special-form "codemetrics.el")
@@ -48,7 +51,6 @@
 (declare-function codemetrics-rules--ruby-binary "codemetrics.el")
 (declare-function codemetrics-rules--rust-outer-loop "codemetrics.el")
 (declare-function codemetrics-rules--scala-call-expression "codemetrics.el")
-(declare-function codemetrics-rules--method-declaration-using-node-name "codemetrics.el")
 
 ;;
 ;; (@* "Rules" )
@@ -177,7 +179,8 @@
   "Return rules for Kotlin."
   `((class_declaration    . codemetrics-rules--class-declaration)
     (object_declaration   . codemetrics-rules--class-declaration)
-    (function_declaration . codemetrics-rules--kotlin-function-declaration)
+    (function_declaration . (lambda (node depth nested)
+                              (codemetrics-rules--method-declaration-using-node-name node depth nested "simple_identifier")))
     (lambda_literal       . (0 t))  ; don't score, but increase nested level
     (anonymous_function   . (0 t))  ; should in theory have same effect as lambda
     (if_expression        . (1 t))
@@ -189,10 +192,12 @@
     (finally_block        . (1 t))
     ("&&"                 . codemetrics-rules--logical-operators)
     ("||"                 . codemetrics-rules--logical-operators)
-    ("?:"                 . codemetrics-rules--kotlin-elvis-operator)
+    ("?:"                 . (lambda (node &rest _)
+                              (codemetrics-rules--operators node '("?:"))))
     ("break"              . codemetrics-rules--kotlin-outer-loop)
     ("continue"           . codemetrics-rules--kotlin-outer-loop)
-    (call_expression      . codemetrics-rules--kotlin-recursion)))
+    (call_expression      . (lambda (node &rest _)
+                              (codemetrics-rules--recursion-using-node-name node "simple_identifier")))))
 
 (defun codemetrics-rules-lua ()
   "Return rules for Lua."

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -349,14 +349,6 @@ For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
 more information."
   (codemetrics-rules--method-declaration-using-node-name node depth nested "identifier"))
 
-;; bash uses the node name word when declaring functions
-(defun codemetrics-rules--bash-function-declaration (node depth nested)
-  "Define rule for function declaration in bash.
-
-For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
-more information."
-  (codemetrics-rules--method-declaration-using-node-name node depth nested "word"))
-
 ;; Kotlin uses its own node name for function identifiers
 (defun codemetrics-rules--kotlin-function-declaration (node depth nested)
   "Define rule for function declaration in Kotlin.
@@ -407,11 +399,6 @@ For argument NODE, see function `codemetrics-analyze' for more information."
 (defun codemetrics-rules--recursion (node &rest _)
   "Handle recursion for most languages uses `identifier' as the keyword."
   (codemetrics-rules--recursion-using-node-name node "identifier"))
-
-;; bash uses its own name for its function invocation names: command_name
-(defun codemetrics-rules--bash-recursion (node &rest _)
-  "Handle recursion for bash."
-  (codemetrics-rules--recursion-using-node-name node "command_name"))
 
 ;; Kotlin uses its own name for the identifiers
 (defun codemetrics-rules--kotlin-recursion (node &rest _)

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -349,14 +349,6 @@ For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
 more information."
   (codemetrics-rules--method-declaration-using-node-name node depth nested "identifier"))
 
-;; Kotlin uses its own node name for function identifiers
-(defun codemetrics-rules--kotlin-function-declaration (node depth nested)
-  "Define rule for function declaration in Kotlin.
-
-For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
-more information."
-  (codemetrics-rules--method-declaration-using-node-name node depth nested "simple_identifier"))
-
 (defun codemetrics-rules--operators (node operators)
   "Define rule for operators from OPERATORS argument.
 
@@ -399,11 +391,6 @@ For argument NODE, see function `codemetrics-analyze' for more information."
 (defun codemetrics-rules--recursion (node &rest _)
   "Handle recursion for most languages uses `identifier' as the keyword."
   (codemetrics-rules--recursion-using-node-name node "identifier"))
-
-;; Kotlin uses its own name for the identifiers
-(defun codemetrics-rules--kotlin-recursion (node &rest _)
-  "Handle recursion for Kotlin."
-  (codemetrics-rules--recursion-using-node-name node "simple_identifier"))
 
 (defun codemetrics-rules--elixir-call (node depth nested)
   "Define rule for Elixir `call' declaration.
@@ -481,12 +468,6 @@ For argument NODE, see function `codemetrics-analyze' for more information."
 
 For argument NODE, see function `codemetrics-analyze' for more information."
   (codemetrics-rules--outer-loop node nil nil 1))
-
-(defun codemetrics-rules--kotlin-elvis-operator (node &rest _)
-  "Define rule for the Elvis operator ?:.
-
-For argument NODE, see function `codemetrics-analyze' for more information."
-  (codemetrics-rules--operators node '("?:")))
 
 (defun codemetrics-rules--julia-macro-expression (node &rest _)
   "Define rule for Julia `macro' expression.

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -339,6 +339,14 @@ For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
 more information."
   (codemetrics-rules--method-declaration-using-node-name node depth nested "identifier"))
 
+;; bash uses the node name word when declaring functions
+(defun codemetrics-rules--bash-function-declaration (node depth nested)
+  "Define rule for function declaration in bash.
+
+For arguments NODE, DEPTH, and NESTED, see function `codemetrics-analyze' for
+more information."
+  (codemetrics-rules--method-declaration-using-node-name node depth nested "word"))
+
 ;; Kotlin uses its own node name for function identifiers
 (defun codemetrics-rules--kotlin-function-declaration (node depth nested)
   "Define rule for function declaration in Kotlin.
@@ -389,6 +397,11 @@ For argument NODE, see function `codemetrics-analyze' for more information."
 (defun codemetrics-rules--recursion (node &rest _)
   "Handle recursion for most languages uses `identifier' as the keyword."
   (codemetrics-rules--recursion-using-node-name node "identifier"))
+
+;; bash uses its own name for its function invocation names: command_name
+(defun codemetrics-rules--bash-recursion (node &rest _)
+  "Handle recursion for bash."
+  (codemetrics-rules--recursion-using-node-name node "command_name"))
 
 ;; Kotlin uses its own name for the identifiers
 (defun codemetrics-rules--kotlin-recursion (node &rest _)

--- a/test/bash-test.el
+++ b/test/bash-test.el
@@ -1,0 +1,55 @@
+;;; bash-test.el --- Bash language tests for codemetrics.el  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Marie Katrine Ekeberg
+
+;; Author: Marie Katrine Ekeberg <mke@themkat.net>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'codemetrics)
+
+(codemetrics-test bash-simple
+  "test/bash/Simple.sh"
+  sh-mode
+  '(3
+    (function_definition . 0)
+    (command . 0)
+    (function_definition . 0)
+    (for_statement . 1)
+    (command . 0)
+    (command . 0)
+    (function_definition . 0)
+    (while_statement . 1)
+    (command . 0)
+    (if_statement . 1)
+    (command . 0)
+    (command . 0)
+    (command . 0)))
+
+(codemetrics-test bash-recursion
+  "test/bash/Recursion.sh"
+  sh-mode
+  '(2
+    (function_definition . 0)
+    (if_statement . 1)
+    (command . 0)
+    (command . 1)
+    (command . 0)
+    (command . 0)))
+
+;;; bash-test.el ends here

--- a/test/bash/Recursion.sh
+++ b/test/bash/Recursion.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function factorial() {
+    n=$1
+    if [[ $n -le 1 ]]
+    then
+        echo "1"
+    else
+        next=$(factorial $(($n-1)))
+        echo $(($n * $next))  
+    fi
+}
+
+factorial $1

--- a/test/bash/Simple.sh
+++ b/test/bash/Simple.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+function usage() {
+    echo "Run with ./Simple.sh"
+}
+
+function print_numbers() {
+    n=$1
+    for i in $(seq 1 $n); do
+        echo "$i"
+    done
+}
+
+function print_numbers_rev() {
+    n=$1
+    while [[ $n -gt 0 ]]; do
+        echo "$n"
+        n=$(($n-1))
+    done
+}
+
+if [[ $# -ne 0 ]]
+then
+    usage
+    exit 1
+fi
+
+print_numbers 10


### PR DESCRIPTION
This PR does 3 things:
- Improve test coverage for bash.
- Fix wrong registration of bash function names used for recursion checking. Also fixes the node name when checking for recursive calls.
- Fix a general bug where calls outside of a function, but not inside another function (i.e, global scope), is counted as recursion. See the bash file `test/bash/Recursion.sh` for example. This bug seems to happen for other languages that allow this as well, but mostly for scripting languages. 