### PR TITLE
Fix incorrect calculation issue with nesting

### DIFF
--- a/Eask
+++ b/Eask
@@ -15,11 +15,11 @@
 (depends-on "emacs" "27.1")
 (depends-on "tree-sitter")
 (depends-on "s")
+(depends-on "dash")
 
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432
 
 (development
  (depends-on "kotlin-mode")
  (depends-on "go-mode")
- (depends-on "tree-sitter-langs")
- (depends-on "dash"))
+ (depends-on "tree-sitter-langs"))

--- a/codemetrics.el
+++ b/codemetrics.el
@@ -257,13 +257,13 @@ details.  Optional argument DEPTH is used for recursive depth calculation."
     (let* ((mode (or mode major-mode))
            (rules (codemetrics--rules mode))
            ;; Collection of nesting levels
-           (nested-depths '())
+           (nested-depths)
            (nested 0)
            (score 0)
            (data)
            ;; Helper for calculating nested value from our collection of nestings
            (calculate-nested-value (lambda (nested-depths)
-                                     (max 0 (- (length nested-depths) 1))))
+                                     (max 0 (1- (length nested-depths)))))
            ;; Global Records
            (codemetrics--recursion-identifier))
       (with-temp-buffer

--- a/test/c-test.el
+++ b/test/c-test.el
@@ -73,4 +73,17 @@
     ("||" . 1)
     ("&&" . 0)))
 
+;; Loosely inspired by go nested prints issue
+;; (for verifying issue with multiple nested ifs inside a for-loop)
+(codemetrics-test c-nested-prints
+  "test/c/NestedPrints.c"
+  c-mode
+  '(5
+    (function_definition . 0)
+    (for_statement . 1)
+    (if_statement . 2)
+    (call_expression . 0)
+    (if_statement . 2)
+    (call_expression . 0)))
+
 ;;; c-test.el ends here

--- a/test/c/NestedPrints.c
+++ b/test/c/NestedPrints.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int main() {
+  int i;
+  for (i = 0; i < 10; i++) {
+    if(i == 0) {
+      printf("Hello there\n")
+    }
+
+    if(i == 9) {
+      printf("General Kenobi\n");
+    }
+  }
+}

--- a/test/go-test.el
+++ b/test/go-test.el
@@ -34,4 +34,26 @@
     (call_expression . 0)
     (for_statement . 1)))
 
+(codemetrics-test recursion-go-code
+  "test/go/Recursion.go"
+  go-mode
+  '(2
+    (function_declaration . 0)
+    (if_statement . 1)
+    (call_expression . 1)))
+
+;; Test of issue:
+;; https://github.com/emacs-vs/codemetrics/issues/7
+(codemetrics-test nested-print-calls
+  "test/go/NestedPrints.go"
+  go-mode
+  '(5
+    (function_declaration . 0)
+    (for_statement . 1)
+    (if_statement . 2)
+    (call_expression . 0)
+    (if_statement . 2)
+    (call_expression . 0)
+    (for_statement . 1)))
+
 ;;; go-test.el ends here

--- a/test/go-test.el
+++ b/test/go-test.el
@@ -44,7 +44,7 @@
 
 ;; Test of issue:
 ;; https://github.com/emacs-vs/codemetrics/issues/7
-(codemetrics-test nested-print-calls
+(codemetrics-test go-nested-print-calls
   "test/go/NestedPrints.go"
   go-mode
   '(5

--- a/test/go-test.el
+++ b/test/go-test.el
@@ -47,7 +47,7 @@
 (codemetrics-test go-nested-print-calls
   "test/go/NestedPrints.go"
   go-mode
-  '(5
+  '(6
     (function_declaration . 0)
     (for_statement . 1)
     (if_statement . 2)

--- a/test/go/NestedPrints.go
+++ b/test/go/NestedPrints.go
@@ -1,0 +1,18 @@
+import "fmt"
+
+func main() {
+	v1 := false
+	v2 := true
+	
+	for {
+		if v1 {
+			fmt.Println(v1)
+		}
+
+		if v2 {
+			fmt.Println(v2)
+		}
+	}
+
+	for {}
+}

--- a/test/go/Recursion.go
+++ b/test/go/Recursion.go
@@ -1,0 +1,7 @@
+func factorial(n int) int {
+	if n <= 1 {
+		return 1
+	}
+	
+	return n * factorial(n - 1)
+}

--- a/test/kotlin-test.el
+++ b/test/kotlin-test.el
@@ -44,14 +44,14 @@
 (codemetrics-test kotlin-break-continue
   "test/kotlin/BreakContinue.kt"
   kotlin-mode
-  '(8
+  '(6
     (function_declaration . 0)
     (call_expression . 0)
     (for_statement . 1)
     (if_expression . 2)
-    ("break" . 1)
+    ("break" . 0)
     (for_statement . 1)
     (if_expression . 2)
-    ("continue" . 1)))
+    ("continue" . 0)))
 
 ;;; kotlin-test.el ends here


### PR DESCRIPTION
# General
Fixes #7.


The nesting implementation gets wrong. This is due to us only checking one level at a time (i.e, the starting level). You notice this in #7, with the second if being incremented once more, instead of having the same nested penalty as the first if. Also, take a look at this C code:
<img width="579" alt="image" src="https://github.com/emacs-vs/codemetrics/assets/5732795/c900723c-5a6c-421e-926d-29829ecf9ce8">


The second if inside the for-statement is not supposed to get an even bigger nesting penalty than the first one. If you read the examples from [the Sonar Cognitive Complexity paper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) you will notice that two similarly nested ifs will get the same score. (page 17 and 18 are very illuminating with relation to examples!). The second one should not get a bigger nested penalty. 


You will also notice that only break and continue with labels should have scores, and they don't seem to have any nested penalties. Only nesting structures seem to have them. That means regular call statements/expressions should not have nesting penalties, so I have removed the nesting penalties to structures that have nesting set to false. 


# Implementation details
Instead of tracking a single nesting level, I decided to track multiple (aka a list of them). That means that every time we have set the nesting to true in our rules, we record the levels in a list. From this list we can easily calculate our `nested` value. We can then in each iteration check if we should move out of any (or all) of our current nested depth values. After knowing the intent, the code should speak for itself. It can probably be improved a bit as well, but it is way more flexible with code that might have weird nestings. The C-code above is calculated properly:
<img width="579" alt="image" src="https://github.com/emacs-vs/codemetrics/assets/5732795/6b909000-db23-4ff6-878b-54e35b671c0a">


Same with the Go-lang defect, at least for all I can see:
<img width="579" alt="image" src="https://github.com/emacs-vs/codemetrics/assets/5732795/0f1563bc-c4c8-439c-8278-bf563fe431fe">


Let me know if anything is unclear 🙂 There are probably also room for improvements in the code. The problem is that when you have worked with something for a while, you get used to your own code. I think a fresh set of eyes can be useful here 🙂 