### PR TITLE
Lua tests and fix for excessive binary_expression calculations

### DIFF
--- a/Eask
+++ b/Eask
@@ -22,6 +22,7 @@
 (development
  (depends-on "kotlin-mode")
  (depends-on "go-mode")
+ (depends-on "lua-mode")
  (depends-on "rust-mode")
  (depends-on "typescript-mode")
  (depends-on "tree-sitter-langs"))

--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -209,8 +209,7 @@
     (while_statement      . (1 t))
     (for_statement        . (1 t))
     (repeat_statement     . (1 t))
-    ;; TODO: this gets wrong... Even simple n * factorial(n - 1) gets high complexity...
-    ;;(binary_expression    . codemetrics-rules--lua-binary-expressions)
+    (binary_expression    . codemetrics-rules--lua-binary-expressions)
     (goto_statement       . (1 nil))
     (function_call        . codemetrics-rules--recursion)))
 

--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -209,7 +209,8 @@
     (while_statement      . (1 t))
     (for_statement        . (1 t))
     (repeat_statement     . (1 t))
-    (binary_expression    . codemetrics-rules--lua-binary-expressions)
+    ;; TODO: this gets wrong... Even simple n * factorial(n - 1) gets high complexity...
+    ;;(binary_expression    . codemetrics-rules--lua-binary-expressions)
     (goto_statement       . (1 nil))
     (function_call        . codemetrics-rules--recursion)))
 

--- a/test/lua-test.el
+++ b/test/lua-test.el
@@ -42,4 +42,13 @@
     (if_statement . 1)
     (function_call . 1)))
 
+(codemetrics-test lua-nesting
+  "test/lua/Nesting.lua"
+  lua-mode
+  '(7
+    (while_statement . 1)
+    (if_statement . 2)
+    (repeat_statement . 2)
+    (if_statement . 1)
+    (goto_statement . 1)))
 ;;; lua-test.el ends here

--- a/test/lua-test.el
+++ b/test/lua-test.el
@@ -1,0 +1,45 @@
+;;; lua-test.el --- Lua language tests for codemetrics.el  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Marie Katrine Ekeberg
+
+;; Author: Marie Katrine Ekeberg <mke@themkat.net>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'codemetrics)
+(require 'lua-mode)
+
+(codemetrics-test lua-simple
+  "test/lua/Simple.lua"
+  lua-mode
+  '(3
+    (function_declaration . 0)
+    (function_call . 0)
+    (function_call . 0)
+    (for_statement . 1)
+    (if_statement . 2)))
+
+(codemetrics-test lua-recursion
+  "test/lua/Recursion.lua"
+  lua-mode
+  '(2
+    (function_declaration . 0)
+    (if_statement . 1)
+    (function_call . 1)))
+
+;;; lua-test.el ends here

--- a/test/lua-test.el
+++ b/test/lua-test.el
@@ -29,10 +29,13 @@
   lua-mode
   '(3
     (function_declaration . 0)
+    (binary_expression . 0)
     (function_call . 0)
+    (binary_expression . 0)
     (function_call . 0)
     (for_statement . 1)
-    (if_statement . 2)))
+    (if_statement . 2)
+    (binary_expression . 0)))
 
 (codemetrics-test lua-recursion
   "test/lua/Recursion.lua"
@@ -40,15 +43,25 @@
   '(2
     (function_declaration . 0)
     (if_statement . 1)
-    (function_call . 1)))
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (function_call . 1)
+    (binary_expression . 0)))
 
 (codemetrics-test lua-nesting
   "test/lua/Nesting.lua"
   lua-mode
   '(7
     (while_statement . 1)
+    (binary_expression . 0)
     (if_statement . 2)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
     (repeat_statement . 2)
+    (binary_expression . 0)
+    (binary_expression . 0)
     (if_statement . 1)
+    (binary_expression . 0)
     (goto_statement . 1)))
 ;;; lua-test.el ends here

--- a/test/lua-test.el
+++ b/test/lua-test.el
@@ -64,4 +64,28 @@
     (if_statement . 1)
     (binary_expression . 0)
     (goto_statement . 1)))
+
+(codemetrics-test lua-logical-operators
+  "test/lua/LogicalOperators.lua"
+  lua-mode
+  '(2
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 1)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 1)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)
+    (binary_expression . 0)))
+
+
+
 ;;; lua-test.el ends here

--- a/test/lua/LogicalOperators.lua
+++ b/test/lua/LogicalOperators.lua
@@ -1,0 +1,5 @@
+local simple_and = 1 == 1 and 1 == 2
+local simple_or = 1 == 1 or 1 == 2
+
+local mix_one = 2 == 2 and 1 == 1 or 2 == 3
+local mix_two = 1 == 2 or 2 == 3 and 3 == 3

--- a/test/lua/Nesting.lua
+++ b/test/lua/Nesting.lua
@@ -1,0 +1,23 @@
+-- Testing various statements and nesting of those
+local my_arr = { 1, 3, 5, 10, 23 }
+local i = 1
+local some_value = 0
+
+::beginning_flow::
+while i < 6 do
+   if my_arr[i] % 2 == 0 then
+      some_value = some_value + 1
+      break
+   end
+
+   local j = 0
+   repeat
+      j = j + 1
+   until j == 10
+end
+
+
+
+if 10 < some_value then
+   goto beginning_flow
+end

--- a/test/lua/Recursion.lua
+++ b/test/lua/Recursion.lua
@@ -1,0 +1,7 @@
+function factorial(n)
+   if 1 <= n then
+      return 1
+   end
+
+   return n * factorial(n - 1)
+end

--- a/test/lua/Simple.lua
+++ b/test/lua/Simple.lua
@@ -1,0 +1,10 @@
+function square(n)
+   return n * n
+end
+
+print("Square of 3: " .. square(3))
+
+for i=1,10 do
+   if 1 == i then   
+   end
+end


### PR DESCRIPTION
# General
Test cases for Lua are mostly inspired by JavaScript. My idea is that it would be easier to work with if we kept some consistency with test names and what we are testing. 

# `binary_expression` error
I guess the original idea for the `binary_expression` rule was to test the logical expressions and their nesting? If not, please let me know 🙂 

Almost everything in Lua is a `binary_expression` (overstatement, but still...). Let us take some quick examples of how many places they actually occur and see the calculations in the MAIN codebase. This is to show why the code fix was done.

## Simple.lua
Notice that each little multiplication, equality check and string concatenation is a `binary_expression`. If we see the debug prints for the Simple.lua file, it looks like this:
<img width="655" alt="image" src="https://github.com/emacs-vs/codemetrics/assets/5732795/3be90232-044f-48b8-8ab6-10e840b00bc2">

We can easily verify that this is from the `binary_expression` operations with the output from tree-sitter:
```yaml
chunk:
  function_declaration:
    identifier:
    parameters:
      identifier:
    block:
      return_statement:
        expression_list:
          binary_expression:
            identifier:
            identifier:
  function_call:
    identifier:
    arguments:
      binary_expression:
        string:
        function_call:
          identifier:
          arguments:
            number:
  for_statement:
    for_numeric_clause:
      identifier:
      number:
      number:
    block:
      if_statement:
        binary_expression:
          number:
          identifier:

```

The calculation is correct here, but that is due to no real nesting of `binary_expression`s.


If we try write a `quad` function instead of `square`, we see the issue quite clearly:

<img width="655" alt="image" src="https://github.com/emacs-vs/codemetrics/assets/5732795/e73e743e-f88f-4c06-bcb1-78989f28e5f9">

As you can see, we now get a score of 1 for the first multiplication. From my understanding of cognitive complexity, only logical expressions should increase the score. I see nothing in any documentation (e.g, the Sonar paper) that arithmetic should increase it.

## Recursion.lua
To really drive the point home, let us look at the recursion example.
<img width="836" alt="image" src="https://github.com/emacs-vs/codemetrics/assets/5732795/be8d44e3-23b5-457c-8547-493c0e0bc536">

Here we see something similar. (one of the `+1`s is correct due to recursive call!). Because the multiplication `n * factorial(n - 1)` is a `binary_expression` that has a `binary_expression` (i.e, `n - 1`) in a child of child nodes, it will get a score. That is not (at least to my knowledge) something that should happen. If it should happen, then it is wrong for ALL other languages...


We could probably continue down this road, and check each test. I don't think that is necessary. Feel free to do so if you want 🙂 

# `binary_expression` fix
if it was not clear, this PR fixes the above consistencies. This is by changing the `binary_expression` checks to only give any score for logical operators that has a logical operator operation as a child. If not, the calculations above will happen resulting in the situation we see in the recursion example.