### PR TITLE
Handle the missing `foreach_statement` for C#

### DIFF
--- a/codemetrics-rules.el
+++ b/codemetrics-rules.el
@@ -102,6 +102,7 @@
     (switch_statement      . (1 t))
     (while_statement       . (1 t))
     (for_statement         . (1 t))
+    (foreach_statement     . (1 t))
     (do_statement          . (1 t))
     (catch_clause          . (1 t))
     (finally_clause        . (1 t))


### PR DESCRIPTION
Trivial! Handles the `foreach` statement in C#